### PR TITLE
281 Fixed bug [GET /user/isOnline/{userId}/] In /user/isOnline/{userId}/ response 401 Unauthorized - always, add test case

### DIFF
--- a/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "refreshTokenValidTimeInMinutes=1440",
         "tokenKey=secretTokenKey"
 })
-public class UserControllerWithSecurityConfigTest {
+class UserControllerWithSecurityConfigTest {
     private static final String userLink = "/user";
 
     private MockMvc mockMvc;
@@ -84,5 +84,13 @@ public class UserControllerWithSecurityConfigTest {
                         .with(anonymous()))
                 .andExpect(status().isUnauthorized());
         verify(userService, times(0)).getEmailNotificationsStatuses();
+    }
+
+    @Test
+    @WithMockUser(username = "Admin", roles = "ADMIN")
+    void checkIfTheUserIsOnline_isOk() throws Exception {
+        mockMvc.perform(get(userLink + "/isOnline/{userId}/", 1L))
+                .andExpect(status().isOk());
+        verify(userService).checkIfTheUserIsOnline(1L);
     }
 }


### PR DESCRIPTION
This bug has been already fixed by some developers in the past. So I've added a test case for review.