### PR TITLE
282 [GET /user/isOnline/{userId}/] In /user/isOnline/{userId}/ need response - 400 Bad request

### DIFF
--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -37,11 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -57,6 +52,8 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -309,6 +306,13 @@ class UserControllerTest {
         mockMvc.perform(get(userLink + "/isOnline/{userId}/", 1))
             .andExpect(status().isOk());
         verify(userService).checkIfTheUserIsOnline(1L);
+    }
+
+    @Test
+    void checkIfTheUserIsOnlineTest_IsBadRequest() throws Exception {
+        mockMvc.perform(get(userLink + "/isOnline/{userId}/", "badRequest"))
+                .andExpect(status().isBadRequest());
+        verifyNoInteractions(userService);
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
@@ -85,4 +85,12 @@ public class UserControllerWithSecurityConfigTest {
                 .andExpect(status().isUnauthorized());
         verify(userService, times(0)).getEmailNotificationsStatuses();
     }
+
+    @Test
+    @WithMockUser(username = "Admin", roles = "ADMIN")
+    void checkIfTheUserIsOnline_isBadRequest() throws Exception {
+        mockMvc.perform(get(userLink + "/isOnline/{userId}/", "badRequest"))
+                .andExpect(status().isBadRequest());
+        verifyNoInteractions(userService);
+    }
 }


### PR DESCRIPTION
This bug has been already fixed by some developers in the past. So I've added a test case for review.