### PR TITLE
314 Fixed bug [PATCH /user/status] response 401 Unauthorized - need 403 Forbidden and added test case for Status update.

### DIFF
--- a/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
@@ -175,4 +175,20 @@ public class UserControllerWithSecurityConfigTest {
                 .andExpect(status().isUnauthorized());
         verifyNoInteractions(userService);
     }
+
+    @Test
+    @WithMockUser(username = "User", roles = "USER")
+    void updateStatusTest_isForbidden() throws Exception {
+        String content = "{\n"
+                + "  \"id\": 0,\n"
+                + "  \"userStatus\": \"DEACTIVATED\"\n"
+                + "}";
+
+        mockMvc.perform(patch(userLink + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(userService);
+    }
 }


### PR DESCRIPTION
A bug that was associated with the status code 401 was solved by adding .requestMatchers("/error").permitAll() to the SecurityConfig file. The task in which this permission was added is #282 Fixed bug in /user/isOnline/{userId }/ need response - 403 Forbidden for the user.