### PR TITLE
315 Fixed bug [PUT /user/updateUserLastActivityTime/{date}] response 401 Unauthorized - always

### DIFF
--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -27,6 +27,7 @@ import greencity.exception.handler.CustomExceptionHandler;
 import greencity.repository.UserRepo;
 import greencity.service.UserService;
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -121,6 +122,20 @@ class UserControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{}"))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateUserLastActivityTimeTest_isOk() throws Exception {
+        Principal principal = mock(Principal.class);
+        UserVO userVO = ModelUtils.TEST_USER_VO;
+
+        when(userService.findByEmail(principal.getName())).thenReturn(userVO);
+
+        LocalDateTime date = LocalDateTime.now();
+
+        mockMvc.perform(put(userLink + "/updateUserLastActivityTime/" + date)
+                        .principal(principal))
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
@@ -32,6 +32,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import static greencity.enums.UserStatus.DEACTIVATED;
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static greencity.enums.Role.ROLE_ADMIN;
@@ -39,8 +40,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
@@ -174,5 +174,14 @@ public class UserControllerWithSecurityConfigTest {
         mockMvc.perform(get(userLink + "/status"))
                 .andExpect(status().isUnauthorized());
         verifyNoInteractions(userService);
+    }
+
+    @Test
+    @WithMockUser(username = "Admin", roles = "ADMIN")
+    void updateUserLastActivityTimeTest_IsOk() throws Exception {
+        LocalDateTime date = LocalDateTime.now();
+
+        mockMvc.perform(put(userLink + "/updateUserLastActivityTime/" + date))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
A bug that was associated with the status code 401 was solved by adding .requestMatchers("/error").permitAll() to the SecurityConfig file. The task in which this permission was added is #282 Fixed bug in /user/isOnline/{userId }/ need response - 403 Forbidden for the user. And added a tests case for update user last activity time.