### PR TITLE
313 Fixed bug [PATCH /user/status] response 401 Unauthorized - need 400 Bad Request and added test case

### DIFF
--- a/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerWithSecurityConfigTest.java
@@ -191,6 +191,17 @@ public class UserControllerWithSecurityConfigTest {
 
         verifyNoInteractions(userService);
     }
+
+    @Test
+    @WithMockUser(username = "Admin", roles = "ADMIN")
+    void updateStatusTest_isBadRequest() throws Exception {
+        mockMvc.perform(patch(userLink + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(userService);
+    }
   
     @Test
     @WithMockUser(username = "Admin", roles = "ADMIN")


### PR DESCRIPTION
A bug that was associated with the status code 401 was solved by adding .requestMatchers("/error").permitAll() to the SecurityConfig file. The task in which this permission was added is #282 Fixed bug in /user/isOnline/{userId }/ need response - 403 Forbidden for the user. And added a tests case for update user last activity time.