### PR TITLE
209 Fixed bug in [POST/email/addEcoNews] need Response 401 Unauthorized, and added test case

### DIFF
--- a/core/src/test/java/greencity/controller/EmailControllerWithSecurityConfigTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerWithSecurityConfigTest.java
@@ -110,6 +110,14 @@ class EmailControllerWithSecurityConfigTest {
         verifyNoInteractions(emailService);
     }
 
+    @Test
+    @WithAnonymousUser
+    void addEcoNews_ReturnsIsUnauthorized() throws Exception {
+        sentPostRequest("{}", "/addEcoNews")
+                .andExpect(status().isUnauthorized());
+        verifyNoInteractions(emailService);
+    }
+
     private ResultActions sentPostRequest(String content, String subLink) throws Exception {
         return mockMvc.perform(post(LINK + subLink)
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
A bug that was associated with the status code 401 was solved by adding .requestMatchers("/error").permitAll() to the SecurityConfig file. The task in which this permission was added is #282 Fixed bug in /user/isOnline/{userId }/ need response - 403 Forbidden for the user. And added a test case for update user last activity time.